### PR TITLE
fix compatibility with win32 to read file

### DIFF
--- a/lib/path.cjs
+++ b/lib/path.cjs
@@ -1,0 +1,6 @@
+if (typeof require !== 'undefined') {
+  var path = require('path')
+  if (path.default) path = path.default
+  exports.default = path
+  module.exports = exports.default
+}

--- a/lib/readFile.js
+++ b/lib/readFile.js
@@ -2,10 +2,12 @@ import JSON5 from './formats/json5.js'
 // eslint-disable-next-line no-unused-vars
 import jsYaml from './formats/yaml.js'
 import * as fsMod from './fs.cjs'
+import * as pathMod from './path.cjs'
 import extname from './extname.js'
 const isDeno = typeof Deno !== 'undefined'
 const YAML = typeof jsYaml !== 'undefined' && jsYaml.load ? jsYaml : undefined
 const fs = fsMod ? (fsMod.default || fsMod) : undefined // because of strange export
+const path = pathMod ? (pathMod.default || pathMod) : undefined
 
 const readFileInNodeSync = (filename) => {
   const data = fs.readFileSync(filename, 'utf8')
@@ -81,10 +83,14 @@ const parseData = (extension, data, options) => {
   return result
 }
 
+const resolvePath = (filename) => {
+  return !path.isAbsolute(filename) && typeof process !== 'undefined' && process.cwd && !fs.existsSync(filename) ? path.join(process.cwd(), filename) : filename
+}
+
 export function readFileSync (filename, options) {
   const ext = extname(filename)
   if (['.js', '.ts'].indexOf(ext) > -1 && typeof require !== 'undefined') {
-    return require(!filename.startsWith('/') && typeof process !== 'undefined' && process.cwd ? `${process.cwd()}/${filename}` : filename)
+    return require(resolvePath(filename))
   }
   let data, stat
   if (isDeno) {
@@ -104,7 +110,7 @@ export function readFile (filename, options = { parse: JSON.parse }) {
   if (['.js', '.ts'].indexOf(ext) > -1 && typeof require !== 'undefined') {
     return new Promise((resolve, reject) => {
       try {
-        resolve({ data: require(!filename.startsWith('/') && typeof process !== 'undefined' && process.cwd ? `${process.cwd()}/${filename}` : filename) })
+        resolve({ data: require(resolvePath(filename)) })
       } catch (err) {
         reject(err)
       }


### PR DESCRIPTION
the way to read js or ts files produce an exception in win32 platform, because in some occasions it try to load files starting with a character distinct to '/' (example C:/somepath/../my_file.js), and the result to join process.cwd() whit the file it's wrong 