### PR TITLE
Export the backend options type

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,25 @@ const Backend = new Backend();
 Backend.init(null, options);
 ```
 
+## TypeScript
+
+To properly type the backend options, you can import the `FsBackendOptions` interface and use it as a generic type parameter to the i18next's `init` method, e.g.:
+
+```ts
+import i18n from 'i18next'
+import FsBackend, { FsBackendOptions } from 'i18next-fs-backend'
+
+i18n
+  .use(FsBackend)
+  .init<FsBackendOptions>({
+    backend: {
+      // fs backend options
+    },
+
+    // other i18next options
+  })
+```
+
 # If set i18next initImmediate option to false it will load the files synchronously
 
 ```js

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ type AddPathOption =
   | string
   | ((language: string, namespace: string) => string)
 
-interface BackendOptions {
+export interface FsBackendOptions {
   /**
    * path where resources get loaded from, or a function
    * returning a path:
@@ -31,11 +31,11 @@ interface BackendOptions {
 }
 
 export default class I18NexFsBackend
-  implements BackendModule<BackendOptions>
+  implements BackendModule<FsBackendOptions>
 {
   static type: "backend";
-  constructor(services?: any, options?: BackendOptions);
-  init(services?: any, options?: BackendOptions): void;
+  constructor(services?: any, options?: FsBackendOptions);
+  init(services?: any, options?: FsBackendOptions): void;
   read(language: string, namespace: string, callback: ReadCallback): void;
   create?(
     languages: string[],
@@ -45,11 +45,5 @@ export default class I18NexFsBackend
   ): void;
   type: "backend";
   services: any;
-  options: BackendOptions;
-}
-
-declare module "i18next" {
-  interface CustomPluginOptions {
-    backend?: BackendOptions;
-  }
+  options: FsBackendOptions;
 }


### PR DESCRIPTION
Also, stop overriding the CustomPluginOptions in the i18next module since that conflicts with other backends.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)