### PR TITLE
Fix types for moduleResolution "node16"

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,25 +3,28 @@
   "version": "2.1.1",
   "private": false,
   "type": "module",
+  "types": "./index.d.ts",
   "main": "./cjs/index.js",
+  "module": "./esm/index.js",
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "types": "./index.d.ts",
+      "types": {
+        "require": "./cjs/index.d.js",
+        "import": "./esm/index.d.js"
+      },
       "require": "./cjs/index.js",
-      "default": "./esm/index.js"
+      "import": "./esm/index.js"
     },
     "./cjs": {
-      "types": "./index.d.ts",
+      "types": "./cjs/index.d.ts",
       "default": "./cjs/index.js"
     },
     "./esm": {
-      "types": "./index.d.ts",
+      "types": "./esm/index.d.ts",
       "default": "./esm/index.js"
     }
   },
-  "module": "./esm/index.js",
-  "types": "./index.d.ts",
   "devDependencies": {
     "@babel/cli": "7.19.3",
     "@babel/core": "7.20.5",
@@ -65,8 +68,8 @@
     "copy:yaml": "cp node_modules/js-yaml/dist/js-yaml.mjs lib/formats/yaml.js",
     "copy": "rm -rf lib/formats && mkdir lib/formats && npm run copy:json5 && npm run copy:yaml",
     "lint": "eslint .",
-    "compile:esm": "rm -rf esm && mkdir esm && BABEL_ENV=esm babel lib -d esm && cp lib/fs.cjs esm/fs.cjs && cp lib/path.cjs esm/path.cjs",
-    "compile:cjs": "rm -rf cjs && mkdir cjs && BABEL_ENV=cjs babel lib -d cjs && echo '{\"type\":\"commonjs\"}' > cjs/package.json && cp lib/fs.cjs cjs/fs.js && cp lib/path.cjs cjs/path.js && node -e \"fs.writeFileSync('cjs/readFile.js', fs.readFileSync('cjs/readFile.js').toString().replace('fs.cjs', 'fs.js').replace('path.cjs', 'path.js'))\" && node -e \"fs.writeFileSync('cjs/writeFile.js', fs.readFileSync('cjs/writeFile.js').toString().replace('fs.cjs', 'fs.js'))\"",
+    "compile:esm": "rm -rf esm && mkdir esm && BABEL_ENV=esm babel lib -d esm && cp index.d.ts esm/index.d.ts && cp lib/fs.cjs esm/fs.cjs && cp lib/path.cjs esm/path.cjs",
+    "compile:cjs": "rm -rf cjs && mkdir cjs && BABEL_ENV=cjs babel lib -d cjs && cp index.d.ts cjs/index.d.ts && echo '{\"type\":\"commonjs\"}' > cjs/package.json && cp lib/fs.cjs cjs/fs.js && cp lib/path.cjs cjs/path.js && node -e \"fs.writeFileSync('cjs/readFile.js', fs.readFileSync('cjs/readFile.js').toString().replace('fs.cjs', 'fs.js').replace('path.cjs', 'path.js'))\" && node -e \"fs.writeFileSync('cjs/writeFile.js', fs.readFileSync('cjs/writeFile.js').toString().replace('fs.cjs', 'fs.js'))\"",
     "compile": "npm run copy && npm run compile:esm && npm run compile:cjs",
     "build": "npm run compile",
     "test": "npm run lint && npm run build && mocha test -R spec --exit --experimental-modules && npm run test:typescript",


### PR DESCRIPTION
Fixes #35

The above issue only happens with `"moduleResolution": "node16"` (or `"module": "Node16"`, which implies `"moduleResolution": "node16"`). I made a minimal project to reproduce the issue: https://github.com/e6c31d/i18next-fs-backend-issue35 .

`package.json` looks really ugly now, but I didn't want to break backwards compatibility by removing redundant fields. In a future major version, it can be cleaned up like below:

```diff
  "type": "module",
-  "types": "./index.d.ts",
-  "main": "./cjs/index.js",
-  "module": "./esm/index.js",
  "exports": {
    "./package.json": "./package.json",
    ".": {
      "types": {
        "require": "./cjs/index.d.js",
        "import": "./esm/index.d.js"
      },
      "require": "./cjs/index.js",
      "import": "./esm/index.js"
+    }
-    },
-    "./cjs": {
-      "types": "./cjs/index.d.ts",
-      "default": "./cjs/index.js"
-    },
-    "./esm": {
-      "types": "./esm/index.d.ts",
-      "default": "./esm/index.js"
-    }
  },
  "devDependencies": {
```
#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included (No, but see [this](https://github.com/e6c31d/i18next-fs-backend-issue35))
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
